### PR TITLE
Change exported attribute of OfferdialogActivity to true

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
         <activity
             android:name=".activity.OfferdialogActivity"
             android:theme="@style/Theme.TransparentDim"
-            android:exported="false"
+            android:exported="true"
             android:screenOrientation="portrait"
             tools:ignore="exported-activity">
             <intent-filter>


### PR DESCRIPTION
I am not sure if this is really the fix, but it sounds reasonable to me. While I am a software developer, I have not yet created Android apps.

In DeepWiki (https://deepwiki.com/internetarchive/wayback-machine-android), I have asked the following question:

> I have a problem with this app on my Samsung Galaxy A54 with Android 16 and all the latest updates:
> The app does not appear in the list to share URLs or content with. I already tried reinstalling the app.

**The answer was:**

> I found the issue! This is actually a bug in the app itself, not a problem with your device.
> 
> The Problem
> The Wayback Machine Android app has a configuration error in its manifest file. The OfferdialogActivity is set up to receive shared URLs, but it's marked as not exported, which prevents it from appearing in the share menu on Android 12 and later versions. AndroidManifest.xml:46-56
> 
> The issue is that the activity has android:exported="false" but contains an intent filter for ACTION_SEND. Starting from Android 12 (API level 31), activities with intent filters that are meant to receive implicit intents from other apps must have android:exported="true". Since you're running Android 16, this configuration prevents the app from appearing in the system share sheet.
> 
> What Should Be Fixed
> The developers need to change line 48 in the AndroidManifest.xml from:
> 
> android:exported="false"
> to: android:exported="true"
> What You Can Do
> Unfortunately, since this is a bug in the app's code, reinstalling won't help. You have a few options:
> 
> Report this issue to the app developers on their GitHub repository
> Wait for an update that fixes this issue
> As a temporary workaround, you can manually open the Wayback Machine app and paste URLs directly into it
> Notes
> This bug was likely introduced when the app was updated to comply with Android 12's requirement to explicitly declare exported activities. The android:exported="false" was added in May 2023, but it conflicts with the intent filter that was added earlier in 2018. The developers probably meant to set it to true since the activity is specifically designed to receive shared content from other apps.


See https://deepwiki.com/search/i-have-a-problem-with-this-app_99ae32bb-c7eb-4938-9d0d-a6e9522fb934
